### PR TITLE
Update Chromebook Setup (grammar)

### DIFF
--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -45,8 +45,8 @@ text, and a small window at the bottom that looks something like this:
 yourusername:~/workspace $
 ```
 
-This bottom area is your _terminal_, where you will give the computer Cloud 9
-has prepared for your instructions. You can resize that window to make it a bit
+This bottom area is your _terminal_. You can use the terminal to send instructions 
+to the remote Cloud 9 computer. You can resize that window to make it a bit
 bigger.
 
 ### Virtual Environment


### PR DESCRIPTION
Per #1451, clarifying the AWS Cloud9 instructions in the Chromebook setup to indicate that the terminal sends commands to the remote computer. 
